### PR TITLE
fix: buildtools now using 1.21.10 instead of 1.21.9

### DIFF
--- a/zip-nms/zip-nms-v1_21_R6/pom.xml
+++ b/zip-nms/zip-nms-v1_21_R6/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot</artifactId>
-			<version>1.21.9-R0.1-SNAPSHOT</version>
+			<version>1.21.10-R0.1-SNAPSHOT</version>
 			<classifier>remapped-mojang</classifier>
 			<scope>provided</scope>
 		</dependency>
@@ -40,10 +40,10 @@
 						<id>remap-obf</id>
 						<configuration>
 							<srgIn>
-								org.spigotmc:minecraft-server:1.21.9-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+								org.spigotmc:minecraft-server:1.21.10-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
 							<reverse>true</reverse>
 							<remappedDependencies>
-								org.spigotmc:spigot:1.21.9-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+								org.spigotmc:spigot:1.21.10-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
 							<remappedArtifactAttached>true</remappedArtifactAttached>
 							<remappedClassifierName>remapped-obf</remappedClassifierName>
 						</configuration>
@@ -58,9 +58,9 @@
 							<inputFile>
 								${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
 							<srgIn>
-								org.spigotmc:minecraft-server:1.21.9-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+								org.spigotmc:minecraft-server:1.21.10-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
 							<remappedDependencies>
-								org.spigotmc:spigot:1.21.9-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+								org.spigotmc:spigot:1.21.10-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix buildtools for 1.21.9 are forced to version 1.21.10 now

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
